### PR TITLE
[Fixed] warning: mnemonic t not found in menu caption Tools

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,7 +1,6 @@
 [
   {
     "caption": "Tools",
-    "mnemonic": "t",
     "id": "tools",
     "children": [
       {


### PR DESCRIPTION
Fixed console output 

> warning: mnemonic t not found in menu caption Tools

See also [**similar pull request**](https://github.com/Sorbing/sublime-unicode-character-insert/pull/1#issue-180462130).

Thanks.